### PR TITLE
Lead trustee individual print helper bug fix

### DIFF
--- a/app/utils/print/AnswerRowConverter.scala
+++ b/app/utils/print/AnswerRowConverter.scala
@@ -58,6 +58,15 @@ class AnswerRowConverter @Inject()(checkAnswersFormatters: CheckAnswersFormatter
       question(query, labelKey, format, changeUrl, canEdit)
     }
 
+    def yesNoQuestionAllowEmptyAnswer(query: Gettable[Boolean],
+                                      labelKey: String,
+                                      changeUrl: String,
+                                      canEdit: Boolean = true): Option[AnswerRow] = {
+      val format = (x: Boolean) => checkAnswersFormatters.yesOrNo(x)
+      question(query, labelKey, format, changeUrl, canEdit) orElse
+        Some(answer(labelKey, changeUrl, canEdit))
+    }
+
     def dateQuestion(query: Gettable[LocalDate],
                      labelKey: String,
                      changeUrl: String,
@@ -126,14 +135,22 @@ class AnswerRowConverter @Inject()(checkAnswersFormatters: CheckAnswersFormatter
                             isVerified: Boolean = false)
                            (implicit rds: Reads[T]): Option[AnswerRow] = {
       userAnswers.get(query) map { x =>
-        AnswerRow(
-          label = HtmlFormat.escape(messages(s"$labelKey.checkYourAnswersLabel", trusteeName)),
-          answer = format(x),
-          changeUrl = changeUrl,
-          canEdit = canEdit,
-          isVerified = isVerified
-        )
+        answer(labelKey, changeUrl, canEdit, isVerified, format(x))
       }
+    }
+
+    private def answer(labelKey: String,
+                       changeUrl: String,
+                       canEdit: Boolean,
+                       isVerified: Boolean = false,
+                       format: Html = HtmlFormat.empty): AnswerRow = {
+      AnswerRow(
+        label = HtmlFormat.escape(messages(s"$labelKey.checkYourAnswersLabel", trusteeName)),
+        answer = format,
+        changeUrl = changeUrl,
+        canEdit = canEdit,
+        isVerified = isVerified
+      )
     }
   }
 }

--- a/app/utils/print/checkYourAnswers/LeadTrusteeIndividualPrintHelper.scala
+++ b/app/utils/print/checkYourAnswers/LeadTrusteeIndividualPrintHelper.scala
@@ -21,6 +21,7 @@ import controllers.leadtrustee.individual.routes._
 import models.UserAnswers
 import pages.leadtrustee.individual._
 import play.api.i18n.Messages
+import queries.Gettable
 import utils.print.AnswerRowConverter
 import viewmodels.{AnswerRow, AnswerSection}
 
@@ -34,15 +35,18 @@ class LeadTrusteeIndividualPrintHelper @Inject()(answerRowConverter: AnswerRowCo
 
     val isLeadTrusteeMatched = userAnswers.isLeadTrusteeMatched
 
+    val inUkQuestion: (Gettable[Boolean], String, String, Boolean) => Option[AnswerRow] =
+      if (isLeadTrusteeMatched) bound.yesNoQuestionAllowEmptyAnswer else bound.yesNoQuestion
+
     def answerRows: Seq[AnswerRow] = Seq(
       bound.nameQuestion(NamePage, s"$prefix.name", NameController.onPageLoad().url, canEdit = !isLeadTrusteeMatched, isVerified = isLeadTrusteeMatched),
       bound.dateQuestion(DateOfBirthPage, s"$prefix.dateOfBirth", DateOfBirthController.onPageLoad().url, canEdit = !isLeadTrusteeMatched, isVerified = isLeadTrusteeMatched),
-      bound.yesNoQuestion(CountryOfNationalityInTheUkYesNoPage, s"$prefix.countryOfNationalityInTheUkYesNo", CountryOfNationalityInTheUkYesNoController.onPageLoad().url),
+      inUkQuestion(CountryOfNationalityInTheUkYesNoPage, s"$prefix.countryOfNationalityInTheUkYesNo", CountryOfNationalityInTheUkYesNoController.onPageLoad().url, true),
       bound.countryQuestion(CountryOfNationalityInTheUkYesNoPage, CountryOfNationalityPage, s"$prefix.countryOfNationality", CountryOfNationalityController.onPageLoad().url),
       bound.yesNoQuestion(UkCitizenPage, s"$prefix.ukCitizen", UkCitizenController.onPageLoad().url, canEdit = !isLeadTrusteeMatched),
       bound.ninoQuestion(NationalInsuranceNumberPage, s"$prefix.nationalInsuranceNumber", NationalInsuranceNumberController.onPageLoad().url, canEdit = !isLeadTrusteeMatched, isVerified = isLeadTrusteeMatched),
       bound.passportOrIdCardDetailsQuestion(PassportOrIdCardDetailsPage, s"$prefix.passportOrIdCardDetails", PassportOrIdCardController.onPageLoad().url),
-      bound.yesNoQuestion(CountryOfResidenceInTheUkYesNoPage, s"$prefix.countryOfResidenceInTheUkYesNo", CountryOfResidenceInTheUkYesNoController.onPageLoad().url),
+      inUkQuestion(CountryOfResidenceInTheUkYesNoPage, s"$prefix.countryOfResidenceInTheUkYesNo", CountryOfResidenceInTheUkYesNoController.onPageLoad().url, true),
       bound.countryQuestion(CountryOfResidenceInTheUkYesNoPage, CountryOfResidencePage, s"$prefix.countryOfResidence", CountryOfResidenceController.onPageLoad().url),
       bound.yesNoQuestion(LiveInTheUkYesNoPage, s"$prefix.liveInTheUkYesNo", LiveInTheUkYesNoController.onPageLoad().url),
       bound.addressQuestion(UkAddressPage, s"$prefix.ukAddress", UkAddressController.onPageLoad().url),

--- a/test/utils/print/checkYourAnswers/LeadTrusteeIndividualPrintHelperSpec.scala
+++ b/test/utils/print/checkYourAnswers/LeadTrusteeIndividualPrintHelperSpec.scala
@@ -31,6 +31,7 @@ class LeadTrusteeIndividualPrintHelperSpec extends SpecBase {
   val ukAddress: UkAddress = UkAddress("value 1", "value 2", None, None, "AB1 1AB")
   val country: String = "DE"
   val nonUkAddress: NonUkAddress = NonUkAddress("value 1", "value 2", None, country)
+  val nino = "AA000000A"
 
   val baseAnswers: UserAnswers = emptyUserAnswers
     .set(NamePage, name).success.value
@@ -38,7 +39,7 @@ class LeadTrusteeIndividualPrintHelperSpec extends SpecBase {
     .set(CountryOfNationalityInTheUkYesNoPage, false).success.value
     .set(CountryOfNationalityPage, country).success.value
     .set(UkCitizenPage, true).success.value
-    .set(NationalInsuranceNumberPage, "AA000000A").success.value
+    .set(NationalInsuranceNumberPage, nino).success.value
     .set(PassportOrIdCardDetailsPage, CombinedPassportOrIdCard("DE", "number", LocalDate.of(1996, 2, 3))).success.value
     .set(CountryOfResidenceInTheUkYesNoPage, false).success.value
     .set(CountryOfResidencePage, country).success.value
@@ -108,6 +109,45 @@ class LeadTrusteeIndividualPrintHelperSpec extends SpecBase {
             AnswerRow(label = Html(messages("leadtrustee.individual.telephoneNumber.checkYourAnswersLabel", name.displayName)), answer = Html("tel"), changeUrl = TelephoneNumberController.onPageLoad().url)
           )
         )
+      }
+
+      "no nationality or residency" when {
+
+        "lead trustee matched" must {
+          "render rows with empty answers" in {
+
+            val helper = injector.instanceOf[LeadTrusteeIndividualPrintHelper]
+
+            val userAnswers = emptyUserAnswers.copy(is5mldEnabled = true)
+              .set(BpMatchStatusPage, FullyMatched).success.value
+              .set(NationalInsuranceNumberPage, nino).success.value
+
+            val result = helper.print(userAnswers, name.displayName)
+            result mustBe AnswerSection(
+              headingKey = None,
+              rows = Seq(
+                AnswerRow(label = Html(messages("leadtrustee.individual.countryOfNationalityInTheUkYesNo.checkYourAnswersLabel", name.displayName)), answer = Html(""), changeUrl = CountryOfNationalityInTheUkYesNoController.onPageLoad().url),
+                AnswerRow(label = Html(messages("leadtrustee.individual.nationalInsuranceNumber.checkYourAnswersLabel", name.displayName)), answer = Html("AA 00 00 00 A"), changeUrl = NationalInsuranceNumberController.onPageLoad().url, canEdit = false, isVerified = true),
+                AnswerRow(label = Html(messages("leadtrustee.individual.countryOfResidenceInTheUkYesNo.checkYourAnswersLabel", name.displayName)), answer = Html(""), changeUrl = CountryOfResidenceInTheUkYesNoController.onPageLoad().url)
+              )
+            )
+          }
+        }
+
+        "lead trustee not matched" must {
+          "not render rows with empty answers" in {
+
+            val helper = injector.instanceOf[LeadTrusteeIndividualPrintHelper]
+
+            val userAnswers = emptyUserAnswers
+
+            val result = helper.print(userAnswers, name.displayName)
+            result mustBe AnswerSection(
+              headingKey = None,
+              rows = Seq()
+            )
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
- Bug: user can't answer nationality and residency questions when maintaining fully matched lead trustee that was registered in 4MLD
- Solution: Renders empty answer rows for "has UK nationality?" and "has UK residency?" ONLY when lead trustee is fully matched (see screenshot)