### PR TITLE
TRUS-4440 [CS] amend css for add to pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,10 +30,16 @@ body:not(.js-enabled) {
   }
 }
 
-// Fallback break for long names and provides padding between the name and type label (change link on mobiles)
+// provides padding between the 1st and 2nd column unless on mobile
+@include govuk-media-query($from: tablet) {
+    .hmrc-add-to-a-list__identifier__first {
+        padding-right: govuk-spacing(4)
+    }
+}
+
+// Fallback break for long names
 .hmrc-add-to-a-list__identifier__first {
     word-break: break-all;
-    padding-right: govuk-spacing(4)
 }
 
 // ----------------

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,12 @@ body:not(.js-enabled) {
   }
 }
 
+// Fallback break for long names and provides padding between the name and type label (change link on mobiles)
+.hmrc-add-to-a-list__identifier__first {
+    word-break: break-all;
+    padding-right: govuk-spacing(4)
+}
+
 // ----------------
 // HMRC Add-to-list pattern - wrapping for unbreakable text
 // taken from govuk-frontend summary list

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,16 @@ body:not(.js-enabled) {
   }
 }
 
+// ----------------
+// HMRC Add-to-list pattern - wrapping for unbreakable text
+// taken from govuk-frontend summary list
+// https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/summary-list/_index.scss#L47
+// ----------------
+.hmrc-add-to-a-list__identifier {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
 p {
   @extend .govuk-body;
 }

--- a/app/views/components/AddToRow.scala.html
+++ b/app/views/components/AddToRow.scala.html
@@ -21,7 +21,7 @@
 @(data: AddRow)(implicit messages: Messages)
 
 <div class="hmrc-add-to-a-list__contents">
-    <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+    <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier__first hmrc-add-to-a-list__identifier--light">
         @data.name
     </dt>
     <dd class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier__second hmrc-add-to-a-list__identifier--light">


### PR DESCRIPTION
CYA was already breaking words as expected
<img width="829" alt="Screenshot 2021-07-29 at 15 52 02" src="https://user-images.githubusercontent.com/62263396/127514756-9050a864-39c1-4964-944f-512149861f1a.png">

Successful word break for long names & padding between 1st and 2nd column
<img width="1050" alt="Screenshot 2021-07-29 at 15 52 51" src="https://user-images.githubusercontent.com/62263396/127514948-e334597d-a5a8-40b7-ac8f-205fd282a9ad.png">

Mobile - padding doesn't affect wrapping columns
<img width="501" alt="Screenshot 2021-07-29 at 15 53 19" src="https://user-images.githubusercontent.com/62263396/127514970-fd1f23e6-2b7f-4a73-82c9-2c69ecdf4aba.png">

